### PR TITLE
Add junit uploads to Trunk

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
         run: npm ci # Install fresh dependencies using the downloaded package-lock.json
 
       - name: Run tests and generate reports
+        id: run-tests
         run: NO_COLOR=true npm run test:ci
 
       - name: Publish Test Report (for non-forks)
@@ -105,6 +106,24 @@ jobs:
         with:
           name: test-results-fork-${{ matrix.node-version }}
           path: packages/*/junit.xml
+
+      - name: Upload Test Results to Trunk (for non-forks)
+        if: always() && (github.event.pull_request.head.repo.full_name == github.repository)
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: packages/*/junit.xml
+          org-slug: gemini-cli
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+          previous-step-outcome: ${{ steps.run-tests.outcome }}
+
+      - name: Upload Test Results to Trunk (for forks)
+        if: always() && (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository)
+        uses: trunk-io/analytics-uploader@v1
+        with:
+          junit-paths: packages/*/junit.xml
+          org-slug: gemini-cli
+          token: ${{ secrets.TRUNK_API_TOKEN }}
+          previous-step-outcome: ${{ steps.run-tests.outcome }}
 
       - name: Upload coverage reports
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4


### PR DESCRIPTION
## TLDR

Added steps to upload junit test results to Trunk using the trunk-io/analytics-uploader action alongside the existing dorny test reporter. This enables flaky test detection and Trunk agent root cause analysis while maintaining existing GitHub PR comment functionality.

## Dive Deeper

The CI workflow now uploads test results to two destinations:
1. Dorny test reporter (existing) - for GitHub PR comments and test result display
2. Trunk (new) - for flaky test detection, analytics, and test health monitoring

The implementation follows the same fork/non-fork pattern as the existing dorny reporter:
- Non-fork PRs: Upload directly when the PR is from the same repository
- Fork PRs: Upload when the PR is from a forked repository

Key changes:
- Added id: run-tests to the test step to reference its outcome
- Added two new trunk upload steps with appropriate conditional logic
- Hardcoded org-slug as gemini-cli (not sensitive information)
- Uses TRUNK_API_TOKEN secret for authentication

## Reviewer Test Plan

To validate these changes:
1. Create a test PR and verify the CI workflow runs successfully
2. Check that both dorny test reporter and trunk upload steps execute
3. Verify that test results appear in GitHub PR comments (dorny reporter)
4. If you have access to the Trunk dashboard, verify test results are uploaded there
5. Test both fork and non-fork PR scenarios if possible

The workflow should continue to work exactly as before, with additional trunk uploads running in parallel.

## Testing Matrix

<!-- Before submitting please validate your changes on as many of these options as possible -->

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | - | - | - |
| npx     | - | - | - |
| Docker   | - | - | - |
| Podman   | - | - | - |
| Seatbelt | - | - | - |
Note: This PR primarily affects CI workflow execution rather than runtime behavior across platforms.

## Linked issues / bugs
<!-- No specific issue was mentioned in the request, but this enables flaky test detection capabilities -->
This PR enables integration with Trunk's flaky test detection system, providing better test reliability insights and monitoring capabilities.
